### PR TITLE
Fix UIWindow size for iOS9

### DIFF
--- a/tweak/DimWindow.m
+++ b/tweak/DimWindow.m
@@ -5,7 +5,15 @@
 @implementation DimWindow
 
 - (DimWindow *)init {
-	if (self = [super initWithFrame:[UIScreen mainScreen].bounds]) {
+    
+    if( [[[UIDevice currentDevice] systemVersion] floatValue] >= 9.0f ){
+        self = [super init];
+    }
+    else{
+        self = [super initWithFrame:[UIScreen mainScreen].bounds];
+    }
+    
+	if (self) {
 	    self.backgroundColor = [UIColor blackColor];
 	    self.windowLevel = 1000001;
 	    self.alpha = 0.45;


### PR DESCRIPTION
Issue: iPads on iOS9 sometimes have the window not big enough. Especially when INVOKING the DimWindow WHILE in landscape mode.

How I tested this (I don't own an iPad on iOS9) I created an Xcode project, included the DimWindow and DimController and simply called the [DimController sharedInstance] which adds the window. I had to set some preferences values and call to update them after the window was created (5s delay).

So first start an iPad simulator in portrait mode, should work fine I think (cant actually remember). Then put it in landscape mode and restart the project. It should now look like this:

![image](https://cloud.githubusercontent.com/assets/899947/11162454/300ecb4a-8ad5-11e5-8e2f-3a0867797298.png)

Basically the coordinate system is messed up.

Now after the code in this PR it just works, like this: 

![image](https://cloud.githubusercontent.com/assets/899947/11162464/57501182-8ad5-11e5-8bde-4766ca75fbb9.png)
